### PR TITLE
chore: update cypress v15.13.1 and dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "cypress-cli-select",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-cli-select",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
-        "@bahmutov/cy-grep": "^3.0.3",
+        "@bahmutov/cy-grep": "^3.0.4",
         "@inquirer/core": "^10.1.11",
-        "find-cypress-specs": "^1.54.10",
+        "find-cypress-specs": "^1.54.12",
         "find-test-names": "^1.29.19",
         "fuse.js": "^7.1.0",
         "inquirer-select-pro": "^1.0.0-alpha.9",
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "cli-testing-library": "^2.0.2",
-        "cypress": "^15.13.0",
+        "cypress": "^15.13.1",
         "jest": "^29.7.0"
       }
     },
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/@bahmutov/cy-grep": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bahmutov/cy-grep/-/cy-grep-3.0.3.tgz",
-      "integrity": "sha512-6eLJHw4JrvkuM+kG42Is33cHCuu+aYyg9eVynKvOWIXxzDExy0lkjqJ2D1RuPNlGoURxQfEIWU2rRisogxLafw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@bahmutov/cy-grep/-/cy-grep-3.0.4.tgz",
+      "integrity": "sha512-ubkx5lCdyIglwrqe9Lg423ACXVbRu8SLOt+oLWeD+ZFoNrzeXa/Bkp9cbc7KuduzTBTPLisy2AxyDoC8eWmw6w==",
       "license": "MIT",
       "dependencies": {
         "cypress-plugin-config": "^2.0.0",
@@ -2929,9 +2929,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.13.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.13.0.tgz",
-      "integrity": "sha512-hJ9sY++TUC/HlUzHVJpIrDyqKMjlhx5PTXl/A7eA91JNEtUWkJAqefQR5mo9AtLra/9+m+JJaMg2U5Qd0a74Fw==",
+      "version": "15.13.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.13.1.tgz",
+      "integrity": "sha512-jLkgo75zlwo7PhXp0XJot+zIfFSDzN1SvTml6Xf3ETM1XHRWnH3Q4LAR3orCo/BsnxPnhjG3m5HYSvn9DAtwBg==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -6447,9 +6447,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-cli-select",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A Cypress cli prompt to select and run specs, tests or tags",
   "main": "index.js",
   "bin": {
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "cli-testing-library": "^2.0.2",
-    "cypress": "^15.13.0",
+    "cypress": "^15.13.1",
     "jest": "^29.7.0"
   },
   "keywords": [
@@ -34,9 +34,9 @@
   },
   "homepage": "https://github.com/dennisbergevin/cypress-cli-select#readme",
   "dependencies": {
-    "@bahmutov/cy-grep": "^3.0.3",
+    "@bahmutov/cy-grep": "^3.0.4",
     "@inquirer/core": "^10.1.11",
-    "find-cypress-specs": "^1.54.10",
+    "find-cypress-specs": "^1.54.12",
     "find-test-names": "^1.29.19",
     "fuse.js": "^7.1.0",
     "inquirer-select-pro": "^1.0.0-alpha.9",


### PR DESCRIPTION
- Updates cypress to v15.13.1
- Updates dependencies find-cypress-specs v1.54.12 and @bahmutov/cy-grep v3.0.4
- Addresses lodash vulnerability [CVE-2026-2950](https://github.com/advisories/GHSA-f23m-r3pf-42rh)